### PR TITLE
Redundant quotes when sending plain text

### DIFF
--- a/packages/ember-model/lib/rest_adapter.js
+++ b/packages/ember-model/lib/rest_adapter.js
@@ -133,8 +133,12 @@ Ember.RESTAdapter = Ember.Adapter.extend({
         if (method === "GET") {
           settings.data = params;
         } else {
-          settings.contentType = settings.contentType || "application/json; charset=utf-8";
-          settings.data = JSON.stringify(params);
+          if (!settings.contentType || /^application\/json/.test(settings.contentType)){
+            settings.contentType = settings.contentType || "application/json; charset=utf-8";
+            settings.data = JSON.stringify(params);
+          } else {
+            settings.data = params;
+          }
         }
       }
 


### PR DESCRIPTION
Добавлялись ненужные кавычки в начале и в конце строки в результате сериализации. При отправки "plain/text" сериализация в JSON не требуется. 
